### PR TITLE
Improved checklist blacklist page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,6 @@ and by implication, [Semantic Versioning](http://semver.org/).
   
 - Added script to hide the table on the checklist page that shows the 
   counts for each age and sex.
+  
+- Added a script to hide checklists from certain observers from the 
+  Recent Visits page for a hotspot or region.

--- a/recent_visits_blacklist.user.js
+++ b/recent_visits_blacklist.user.js
@@ -1,11 +1,12 @@
 // ==UserScript==
 // @name     Recent visits observer blacklist
 // @namespace https://github.com/ProjectBabbler/ebird/
-// @version  1.0.0
+// @version  2.0.0
 // @grant    none
 // @include  https://ebird.org/region/*/activity*
+// @include  https://ebird.org/hotspot/*/activity*
 // @require  https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js
-// @description Hide checklists from certain observers on the recent visits page for a region or hotspot
+// @description Hide checklists from selected observers on the recent visits page for a region or hotspot
 // @copyright 2018 Stuart MacKay (https://github.com/ProjectBabbler/ebird-superscripts)
 // @homepage https://github.com/ProjectBabbler/ebird-superscripts
 // @author smackay
@@ -16,16 +17,23 @@
 (function() {
     'use strict';
 
-    // Add the names of the observers you want to exclude from the recent
-    // visits page for a hotspot or region.
+    var name;
 
-    const blacklist = ['Stuart MacKay']; // just an example ;)
+    function hideObserver(name) {
+        $('td[headers="observer"]').each(function () {
+            if (name ===  $(this).data('observer')) {
+                $(this).closest('tr').addClass('hidden');
+            }
+        });
+    }
 
     $('td[headers="observer"]').each(function () {
-        let name = $(this).contents().text().trim().replace(/\s{2,}/, ' ');
-        if (blacklist.includes(name)) {
-            $(this).parent().addClass('hidden');
-        }
+        name = $(this).contents().text().trim().replace(/\s{2,}/, ' ');
+        $(this).prepend('<span style="font-weight: normal;" title="Hide all checklists from' + name + '">x</span> ');
+        $(this).data('observer', name);
+        $(this).children(":first").click(function () {
+            hideObserver(name);
+        });
     });
 
 })();

--- a/recent_visits_blacklist.user.js
+++ b/recent_visits_blacklist.user.js
@@ -1,0 +1,31 @@
+// ==UserScript==
+// @name     Recent visits observer blacklist
+// @namespace https://github.com/ProjectBabbler/ebird/
+// @version  1.0.0
+// @grant    none
+// @include  https://ebird.org/region/*/activity*
+// @require  https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js
+// @description Hide checklists from certain observers on the recent visits page for a region or hotspot
+// @copyright 2018 Stuart MacKay (https://github.com/ProjectBabbler/ebird-superscripts)
+// @homepage https://github.com/ProjectBabbler/ebird-superscripts
+// @author smackay
+// @license MIT
+// @updateURL https://openuserjs.org/meta/smackay/recent_visits_blacklist.meta.js
+// ==/UserScript==
+
+(function() {
+    'use strict';
+
+    // Add the names of the observers you want to exclude from the recent
+    // visits page for a hotspot or region.
+
+    const blacklist = ['Stuart MacKay']; // just an example ;)
+
+    $('td[headers="observer"]').each(function () {
+        let name = $(this).contents().text().trim().replace(/\s{2,}/, ' ');
+        if (blacklist.includes(name)) {
+            $(this).parent().addClass('hidden');
+        }
+    });
+
+})();


### PR DESCRIPTION
Rewrote the checklist blacklist page so the user does not have to edit the script to add names. Instead a checkmark is added to each observer name and the user clicks on it to remove all checklist for that observer. The rewrite only works until the page is loaded but it's more interactive and more flexible.