### PR TITLE
Observer name no longer gets lost.

### DIFF
--- a/recent_visits_blacklist.user.js
+++ b/recent_visits_blacklist.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name     Recent visits observer blacklist
-// @version  2.0.1
+// @version  2.0.2
 // @description Hide checklists from selected observers on the recent visits page for a region or hotspot
 // @include  https://ebird.org/region/*/activity*
 // @include  https://ebird.org/hotspot/*/activity*
@@ -18,7 +18,7 @@
 
     function hideObserver(name) {
         $('td[headers="observer"]').each(function () {
-            if (name ===  $(this).data('observer')) {
+            if (name ===  $(this).attr('data-observer')) {
                 $(this).closest('tr').addClass('hidden');
             }
         });
@@ -27,7 +27,7 @@
     $('td[headers="observer"]').each(function () {
         let name = $(this).contents().text().trim().replace(/\s{2,}/, ' ');
         $(this).prepend('<span style="font-weight: normal;" title="Hide all checklists from ' + name + '">x</span> ');
-        $(this).data('observer', name);
+        $(this).attr('data-observer', name);
         $(this).children(":first").click(function () {
             hideObserver(name);
         });


### PR DESCRIPTION
The name of the observer was stored for each entry in the list using
jQuery's data() but when another script ran the data for the node was
getting lost. To workaround this the name of the observer is stored on
the DOM node using attr().