### PR TITLE
Updated URLs for triggering scripts to process checklist page.

### DIFF
--- a/checklist_counts_first.user.js
+++ b/checklist_counts_first.user.js
@@ -1,8 +1,9 @@
 // ==UserScript==
 // @name     Checklist Species counts first
-// @version  1.0.0
+// @version  1.0.1
 // @description Split the species list and show those species with counts first
 // @include  https://ebird.org/view/checklist/*
+// @include  https://ebird.org/*/view/checklist/*
 // @require  https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js
 // @namespace https://github.com/ProjectBabbler/ebird/
 // @author smackay

--- a/checklist_hide_age_table.user.js
+++ b/checklist_hide_age_table.user.js
@@ -1,7 +1,8 @@
 // ==UserScript==
 // @name     Checklist hide age table
-// @version  1.0.1
+// @version  1.0.2
 // @description Hide the table showing the counts for age and sex
+// @include  https://ebird.org/view/checklist/*
 // @include  https://ebird.org/*/view/checklist/*
 // @require  https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js
 // @namespace https://github.com/ProjectBabbler/ebird/


### PR DESCRIPTION
The URL for a checklist page might differ according to how you arrive at
the page. If you arrive on via the "Recent Visits" tab on a country level
region page, https://ebird.org/region/PT/activity?yr=all&m= then the page
URL takes the form, https://ebird.org/portugal/view/checklist/S43979454
but if you arrive from "Recent Visits" page at the region or hotspot level,
https://ebird.org/region/PT-11/activity?yr=all&m= then the URL takes the
form, https://ebird.org/view/checklist/S43979454. Note the name of the
country is omitted.

The @include directives for the scripts running on a checklist page were
updated to allow both URL forms.