### PR TITLE
Checklists on the Recent Visits page are opened in a new tab.

### DIFF
--- a/recent_visits_new_tab.js
+++ b/recent_visits_new_tab.js
@@ -1,0 +1,23 @@
+// ==UserScript==
+// @name     Recent visit checklists in new tab
+// @version  1.0.0
+// @description Links on the Recent Visits page opens each checklist in a new tab.
+// @include  https://ebird.org/region/*/activity*
+// @include  https://ebird.org/hotspot/*/activity*
+// @require  https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js
+// @namespace https://github.com/ProjectBabbler/ebird/
+// @author smackay
+// @copyright 2018 Stuart MacKay (https://github.com/ProjectBabbler/ebird-superscripts)
+// @license MIT
+// @homepage https://github.com/ProjectBabbler/ebird-superscripts
+// @grant    none
+// ==/UserScript==
+
+(function() {
+    'use strict';
+
+    $('td.obstable-date a').each(function () {
+     $(this).attr('target', '_blank');
+    });
+
+})();


### PR DESCRIPTION
The date for each recent visit is a link which opens the page for the
corresponding checklist in the same window/tab. Unfortunately the
Recent Visits page is not cached and it takes a while to load the
page - that makes the whole process of seeing what's been seen rather
slow. Of course you can right-click on the link and open the checklist
in a new tab so avoid reloading the Recent Visits page each time but
that is slightly awkwards and is still somewhat a slow process.

This script modifies the links so the target is set to _blank. This
will open the checklist in either new tab or window. This is browser
specific but generally browsers will open a new tab.

That still does not quite solve the problem since the browser will
switch to the new tab. However in FireFox you can fix this by changing
the config setting, browser.tabs.loadDivertedInBackground=true.